### PR TITLE
Remove ${SAXON} for saxon.*\.jar on ${user.dir}/lib

### DIFF
--- a/pdi/create-transform-script.ktr
+++ b/pdi/create-transform-script.ktr
@@ -352,6 +352,7 @@
     <type>GetFileNames</type>
     <description/>
     <distribute>Y</distribute>
+    <custom_distribution/>
     <copies>1</copies>
          <partitioning>
            <method>none</method>
@@ -363,7 +364,7 @@
     <doNotFailIfNoFile>N</doNotFailIfNoFile>
     <rownum>N</rownum>
     <isaddresult>Y</isaddresult>
-    <filefield>Y</filefield>
+    <filefield>N</filefield>
     <rownum_field/>
     <filename_Field>saxon</filename_Field>
     <wildcard_Field/>
@@ -371,13 +372,13 @@
     <dynamic_include_subfolders>N</dynamic_include_subfolders>
     <limit>0</limit>
     <file>
-      <name/>
-      <filemask/>
-      <exclude_filemask/>
-      <file_required/>
-      <include_subfolders/>
+      <name>&#x24;&#x7b;user.dir&#x7d;&#x2f;lib&#x2f;</name>
+      <filemask>saxon-.&#x2a;&#x5c;.jar</filemask>
+      <exclude_filemask>.&#x2a;dom.&#x2a;</exclude_filemask>
+      <file_required>Y</file_required>
+      <include_subfolders>N</include_subfolders>
     </file>
-     <cluster_schema/>
+    <cluster_schema/>
  <remotesteps>   <input>   </input>   <output>   </output> </remotesteps>    <GUI>
       <xloc>266</xloc>
       <yloc>269</yloc>

--- a/pdi/document-folder.kjb
+++ b/pdi/document-folder.kjb
@@ -21,11 +21,6 @@
             <default_value>&#47;home&#47;rbouman&#47;projects&#47;kettle-cookbook&#47;docs</default_value>
             <description>Directory where you want the documentation to be placed</description>
         </parameter>
-        <parameter>
-            <name>SAXON</name>
-            <default_value>.&#47;libext&#47;saxon9.jar</default_value>
-            <description>Location of the saxon lib. Default location assumes you&apos;re running kettle from it&apos;s home directory.</description>
-        </parameter>
     </parameters>
     <slaveservers>
     </slaveservers>

--- a/pdi/process-files.ktr
+++ b/pdi/process-files.ktr
@@ -19,11 +19,6 @@
             <default_value>D:\tmp\kettle-cookbook-doc</default_value>
             <description>null</description>
         </parameter>
-        <parameter>
-            <name>SAXON</name>
-            <default_value>.&#47;libext&#47;saxon8.jar</default_value>
-            <description/>
-        </parameter>
     </parameters>
     <log>
 <trans-log-table><connection/>
@@ -233,18 +228,6 @@
       <field>
         <name>file_separator</name>
         <variable>${file.separator}</variable>
-        <type>String</type>
-        <format/>
-        <currency/>
-        <decimal/>
-        <group/>
-        <length>-1</length>
-        <precision>-1</precision>
-        <trim_type>none</trim_type>
-      </field>
-      <field>
-        <name>saxon</name>
-        <variable>${SAXON}</variable>
         <type>String</type>
         <format/>
         <currency/>


### PR DESCRIPTION
The one thing were this version wasn't working here, even with PDI 6, was the need for a saxon reference. Since PDI comes with saxon packed on /lib dir, why not drop the ${SAXON} variable altogether?